### PR TITLE
Force npm to accept Astro 6 for Keystatic

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
     "preview": "astro preview",
     "astro": "astro"
   },
+  "overrides": {
+    "@keystatic/astro": {
+      "astro": "$astro"
+    }
+  },
   "dependencies": {
     "@astrojs/markdoc": "^1.0.3",
     "@astrojs/node": "^10.0.5",


### PR DESCRIPTION
This error occurs because Astro 6 was recently released, and @keystatic/astro hasn't updated its metadata to officially support it yet. The project is using Astro 6, but Keystatic is strictly looking for versions 2, 3, 4, or 5.