### PR TITLE
Remove base path configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,6 @@ export default defineConfig({
   adapter: node({
     mode: 'standalone',
   }),
-  base: '/portfolio',
   integrations: [react(), markdoc(), keystatic()],
   root: '',
   site: 'https://felipeuliana.github.io',


### PR DESCRIPTION
📝 Summary

This PR addresses the 404 error encountered upon deployment. After investigating the Astro build output, it was determined that the base configuration in astro.config.mjs was causing internal routing to resolve to an incorrect directory. Removing this configuration forces the build to resolve paths relative to the root, which fixes the asset loading and routing on the production server.
🚀 Changes

    astro.config.mjs: Removed the base property to ensure paths resolve correctly from the root.

🧪 Testing Done

    Local Build: Ran npm run build and verified that the dist/ folder structure is correct.

    Preview: Ran npx astro preview and confirmed that all pages and assets (CSS/JS/Images) load without 404 errors.

    Deployment: (After merging) This should resolve the 404 status on the production URL.

📋 Checklist

    [x] I have performed a self-review of my code.

    [x] I have tested the build locally.