### PR TITLE
Revert "fix: Remove base value from config"

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,7 @@ export default defineConfig({
   adapter: node({
     mode: 'standalone',
   }),
+  base: '/portfolio',
   integrations: [react(), markdoc(), keystatic()],
   output: 'static',
   root: '',


### PR DESCRIPTION
📝 Summary

This PR reverts commit 9cf7690d. The previous change removed the base property from the Astro configuration to resolve 404 errors.

We are restoring the base configuration to ensure compatibility with the deployment target's subdirectory structure.

🔄 Reversion Details

    Reverts: Commit 9cf7690d1c466d6972d31d24c488cc986575c426

🚀 Restored Changes

    astro.config.mjs: Re-inserted the base property to match the repository name/subdirectory.

📋 Checklist

    [x] Confirmed that this revert restores the configuration to its previous known state.

    [x] Verified that the repository name matches the restored base value.